### PR TITLE
generalization of quicksynth

### DIFF
--- a/docs/source/instruments/QUICKSYNTH.rst
+++ b/docs/source/instruments/QUICKSYNTH.rst
@@ -1,7 +1,8 @@
 
-Microwave synthesizer FSL0010
-=============================
-FSW0010 Microwave Synthesizer by National Instruments
+Microwave synthesizers by QuickSynth
+====================================
+
+In these category, qtics supports the FSW and FSL series by Microwave Synthesizer by National Instruments
 The manual of this instrument and similar products can be found `here <http://ni-microwavecomponents.com/quicksyn-lite#documentation>`_. The SCPI commands and functions can be found in the `communications specifications <http://ni-microwavecomponents.com/manuals/5580522-01.pdf>`_.
 
 Base class: :class:`qtics.instruments.serial_inst.SerialInst`.
@@ -11,7 +12,7 @@ Example of operation
 
 .. code-block:: python
 
-  from qtics import FSL0010
+  from qtics import FSL0010 # also FSL0020, FSW0010, FSW0020
 
   synth = FSL0010(name = "mySynth", address = "/dev/ttyUSB0")
   synth.freq = 5.3e9

--- a/docs/source/instruments/modules.rst
+++ b/docs/source/instruments/modules.rst
@@ -7,7 +7,7 @@ Supported Instruments
    R591722600
    3494_64
    SIM928
-   FSL0010
+   QUICKSYNTH
    6514
    2231A
    SMA100B

--- a/src/qtics/__init__.py
+++ b/src/qtics/__init__.py
@@ -13,13 +13,13 @@ from qtics.instruments.network.RS_SMA100B import SMA100B
 from qtics.instruments.network.triton_ctrl import Triton
 from qtics.instruments.serial.keithley2231a import Keithley2231A
 from qtics.instruments.serial.keithley6514 import Keithley6514
+from qtics.instruments.serial.quick_synth import FSL0010, FSL0020, FSW0010, FSW0020
 from qtics.instruments.serial.rf_attenuator_3494_64.rf_attenuator_3494_64 import (
     Attenuator_3494_64,
 )
 from qtics.instruments.serial.rf_switch_R591722600.rf_switch_R591722600 import (
     Switch_R591,
 )
-from qtics.instruments.serial.synth_FSL0010 import FSL0010
 from qtics.instruments.serial.valon_5019 import VALON5019
 from qtics.instruments.serial.voltage_source_SIM928 import SIM928
 

--- a/src/qtics/instruments/serial/quick_synth.py
+++ b/src/qtics/instruments/serial/quick_synth.py
@@ -1,5 +1,5 @@
 """
-FSL0010 QuickSyn microwave synthesizer by National Instruments.
+QuickSyn microwave synthesizers by National Instruments.
 
 .. module:: synth_FSL0010.py
 .. moduleauthor:: Pietro Campana <campana.pietro@campus.unimib.it>
@@ -14,8 +14,8 @@ from qtics.instruments import SerialInst
 DEFAULT_FREQ_SCALE = 1e-3  # Convert mHz to Hz
 
 
-class FSL0010(SerialInst):
-    """FSL0010 QuickSyn microwave synthesizer by National Instruments."""
+class FSQS(SerialInst):
+    """QuickSyn microwave synthesizer by National Instruments."""
 
     def __init__(
         self,
@@ -33,6 +33,9 @@ class FSL0010(SerialInst):
             name, address, baudrate, bytesize, parity, stopbits, timeout, sleep
         )
 
+        self.min_freq = 0.5e9
+        self.max_freq = 10e9
+
     @property
     def freq(self) -> float:
         """Output signal frequency in Hz."""
@@ -40,7 +43,7 @@ class FSL0010(SerialInst):
 
     @freq.setter
     def freq(self, freq: float):
-        freq = self.validate_range(freq, 0.65e9, 10e9)
+        freq = self.validate_range(freq, self.min_freq, self.max_freq)
         self.write(f"FREQ {freq / DEFAULT_FREQ_SCALE}mlHz")
 
     @property
@@ -71,3 +74,31 @@ class FSL0010(SerialInst):
     def temperature(self) -> float:
         """Temperature in degrees Celsius."""
         return float(self.query("DIAG:MEAS? 21"))
+
+
+class FSL0010(FSQS):
+    """FSL_0010 QuickSyn."""
+
+    min_freq = 0.65e9
+    max_freq = 10e9
+
+
+class FSL0020(FSQS):
+    """FSW_0020 QuickSyn."""
+
+    min_freq = 0.65e9
+    max_freq = 20e9
+
+
+class FSW0010(FSQS):
+    """FSL_0010 QuickSyn."""
+
+    min_freq = 0.5e9
+    max_freq = 10e9
+
+
+class FSW0020(FSQS):
+    """FSW_0020 QuickSyn."""
+
+    min_freq = 0.5e9
+    max_freq = 20e9


### PR DESCRIPTION
Closes #65.
Looking at the documentation () and including only the func in our driver, the generalization to different instrument of the series was very easy and just entailed a minimal change in the frequency range.
